### PR TITLE
ci: add multiarch Docker image build to release workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -13,9 +13,14 @@ on:
 
 permissions:
   contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-upload:
+  build-deb:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,3 +51,44 @@ jobs:
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: build and push multiarch Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

This PR adds multiarch Docker image building and publishing to GitHub Container Registry when a new release is triggered by release-plz.

## Changes

- Added `build-docker` job to `release-package.yml` workflow
- Builds Docker images for `linux/amd64` and `linux/arm64` platforms
- Publishes to `ghcr.io/jdrouet/inapt`
- Tags images with semver versions:
  - `0.3.0` (full version)
  - `0.3` (major.minor)
  - `0` (major only)
  - `latest` (on default branch)
- Uses GitHub Actions cache for faster builds
- Runs in parallel with existing `.deb` package builds

## Usage

After a release, users can pull the image:

```bash
docker pull ghcr.io/jdrouet/inapt:latest
# or specific version
docker pull ghcr.io/jdrouet/inapt:0.3.0
```
