### PR TITLE
build(deps): batch dependabot updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,14 +533,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3400,9 +3399,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -3410,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
 dependencies = [
  "console",
  "similar",
@@ -4521,15 +4520,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "temp-file"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ff282c3f91797f0acb021f3af7fffa8a78601f0f2fd0a9f79ee7dcf9a9af9e"
+checksum = "e08eac0f10a143ffa8883ff5964642eef36d867436cc389812c32790c778105f"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camellia"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ anyhow = "1.0"
 bollard = "0.21"
 bytes = "1"
 mockall = "0.15"
-similar-asserts = "1.7"
+similar-asserts = "2.0"
 tempfile = "3"
 walkdir = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_json = "1.0"
 sha2 = "0.10"    # optional: for SHA256 of the .deb
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 tar = "0.4"
-temp-file = "0.1"
+temp-file = "0.2"
 thiserror = "2.0"
 tokio = { version = "1.48", default-features = false, features = ["fs", "macros", "net", "rt-multi-thread"] }
 toml = "1.0"


### PR DESCRIPTION
Addresses the open Dependabot PRs (#98, #99, #100, #101, #102) in a single batch.

## Merged
- **bytes** 1.12.0 → 1.12.1 (#100) — dev-dependency, patch (lockfile only).
- **similar-asserts** 1.7.0 → 2.0.0 (#101) — dev-dependency; the `assert_eq!` macro API is unchanged.
- **temp-file** 0.1.9 → 0.2.0 (#102) — compiles and tests pass unchanged.

## Skipped (incompatible, PRs should be closed)
- **rand** 0.8 → 0.10 (#99) — rand 0.10 uses `rand_core` 0.9, but `rsa` 0.9 (`RsaPrivateKey::new`) requires a `rand_core` 0.6 `CryptoRngCore`. rand 0.10's `ThreadRng` cannot satisfy that bound. Can't land without an `rsa` release built on `rand_core` 0.9, which doesn't exist yet.
- **sha2** 0.10 → 0.11 (#98) — sha2 0.11 pulls in `digest` 0.11, but both `rsa` 0.9 and `sequoia-openpgp` 2.1 pin `sha2` ^0.10 / `digest` 0.10. Resolution fails and the RSA signer's `SigningKey::<Sha256>` / `VerifyingKey::<Sha256>` no longer satisfy their trait bounds.

Full test suite (93 tests) passes.