### PR TITLE
fix: remove redundant reference in genrsakey print

### DIFF
--- a/src/bin/genrsakey.rs
+++ b/src/bin/genrsakey.rs
@@ -9,7 +9,7 @@ fn main() -> anyhow::Result<()> {
     let private_pem = private_key.to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)?;
     let public_pem = public_key.to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)?;
 
-    print!("{}", &*private_pem);
+    print!("{}", *private_pem);
     print!("{public_pem}");
 
     Ok(())


### PR DESCRIPTION
Clippy 1.97 added `useless_borrows_in_formatting`, which fails `code-checking` with `-Dwarnings`. This blocks every open dependabot PR — including the GitHub Actions ones that touch no Rust.