### PR TITLE
build(deps): drop rand in favour of rsa::rand_core::OsRng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,7 +1674,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "rand 0.8.6",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ opentelemetry-appender-tracing = { version = "0.32", default-features = false }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "tls-ring", "tls-roots"] }
 opentelemetry-semantic-conventions = { version = "0.32", default-features = false, features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["logs", "metrics", "rt-tokio", "trace"] }
-rand = "0.8"
 rsa = { version = "0.9", features = ["pem"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 reqwest-middleware = { version = "0.5", features = ["query"] }

--- a/src/adapter_rsa/mod.rs
+++ b/src/adapter_rsa/mod.rs
@@ -19,7 +19,7 @@ fn default_key_name() -> String {
 
 impl Config {
     fn generate_private_key(&self) -> anyhow::Result<()> {
-        let mut rng = rand::thread_rng();
+        let mut rng = rsa::rand_core::OsRng;
         let private_key =
             RsaPrivateKey::new(&mut rng, 4096).context("unable to generate RSA private key")?;
 
@@ -92,7 +92,7 @@ mod tests {
         let key_path = dir.path().join("existing-key.pem");
 
         // Generate a key first
-        let mut rng = rand::thread_rng();
+        let mut rng = rsa::rand_core::OsRng;
         let private_key = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
         let pem =
             rsa::pkcs1::EncodeRsaPrivateKey::to_pkcs1_pem(&private_key, rsa::pkcs1::LineEnding::LF)

--- a/src/adapter_rsa/signer.rs
+++ b/src/adapter_rsa/signer.rs
@@ -30,7 +30,7 @@ mod tests {
     use crate::domain::prelude::RsaSigner;
 
     fn build_test_client() -> super::super::RsaClient {
-        let mut rng = rand::thread_rng();
+        let mut rng = rsa::rand_core::OsRng;
         let private_key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
         super::super::RsaClient {
             private_key,
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn should_load_key_from_pem_and_sign() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rsa::rand_core::OsRng;
         let private_key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
         let pem =
             rsa::pkcs1::EncodeRsaPrivateKey::to_pkcs1_pem(&private_key, rsa::pkcs1::LineEnding::LF)

--- a/src/bin/genrsakey.rs
+++ b/src/bin/genrsakey.rs
@@ -2,7 +2,7 @@ use rsa::RsaPrivateKey;
 use rsa::pkcs1::{EncodeRsaPrivateKey, EncodeRsaPublicKey};
 
 fn main() -> anyhow::Result<()> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rsa::rand_core::OsRng;
     let private_key = RsaPrivateKey::new(&mut rng, 4096)?;
     let public_key = private_key.to_public_key();
 

--- a/tests/e2e_apk_repository.rs
+++ b/tests/e2e_apk_repository.rs
@@ -342,7 +342,7 @@ fn generate_rsa_private_key(path: &std::path::Path) -> Result<()> {
     use rsa::RsaPrivateKey;
     use rsa::pkcs1::EncodeRsaPrivateKey;
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rsa::rand_core::OsRng;
     let private_key =
         RsaPrivateKey::new(&mut rng, 2048).context("Failed to generate RSA private key")?;
     let pem = private_key


### PR DESCRIPTION
Closes #99.

`rand` was only used to seed RSA key generation (4 call sites + 1 test). `rsa` 0.9 pins `rand_core` 0.6, so any `rand` 0.9+ RNG fails to satisfy its `CryptoRngCore` bound — dependabot's rand 0.10 bump (#99) could never compile.

Using `rsa::rand_core::OsRng` drops the direct dependency entirely and stops the bump from reappearing. `rsa` 0.10 is still an RC; revisit when it lands.

- `cargo clippy --all-targets --all-features --tests --workspace` clean
- `cargo test --tests --workspace`: 93 passed