### PR TITLE
build(deps): Bump md-5 from 0.10.6 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +735,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -750,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -762,6 +768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1691,7 +1698,7 @@ dependencies = [
  "hex",
  "hostname",
  "http",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "mockall",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -2936,7 +2943,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -3301,7 +3308,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f606421e4a6012877e893c399822a4ed4b089164c5969424e1b9d1e66e6964b"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "generic-array 1.4.3",
 ]
@@ -3453,7 +3460,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2f20f4049197e03db1104a6452f4d9e96665d79f880198dce4a7026ba5f267"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "hmac 0.12.1",
  "hybrid-array 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3"
 hostname = "0.4"
 hex = "0.4"
 http = "1.4"
-md-5 = "0.10"
+md-5 = "0.11"
 opentelemetry = { version = "0.32", default-features = false }
 opentelemetry-appender-tracing = { version = "0.32", default-features = false }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "tls-ring", "tls-roots"] }

--- a/src/adapter_sqlite/mod.rs
+++ b/src/adapter_sqlite/mod.rs
@@ -514,7 +514,10 @@ impl SqliteStorage {
     /// Compute translation metadata from architectures.
     fn compute_translation_metadata(architectures: &[ArchitectureMetadata]) -> TranslationMetadata {
         use flate2::write::GzEncoder;
-        use md5::Digest;
+        // md-5 and sha2 are on different digest versions, so each Digest trait
+        // must be imported for its own hasher.
+        use md5::Digest as _;
+        use sha2::Digest as _;
         use std::collections::HashSet;
         use std::io::Write;
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -8,7 +8,10 @@ use std::{
 
 use flate2::{Compression, write::GzEncoder};
 
-use sha2::Digest;
+// md-5 and sha2 are on different digest versions, so each Digest trait must be
+// imported for its own hasher.
+use md5::Digest as _;
+use sha2::Digest as _;
 
 pub(crate) mod entity;
 pub(crate) mod prelude;
@@ -635,8 +638,6 @@ impl ReleaseMetadataBuilder {
     fn build_translation_metadata(
         architectures: &[entity::ArchitectureMetadata],
     ) -> anyhow::Result<entity::TranslationMetadata> {
-        use sha2::Digest;
-
         // Collect unique packages by name (deduplicate across architectures)
         let mut seen_packages: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut entries = Vec::new();
@@ -718,15 +719,15 @@ impl ArchitectureMetadataBuilder {
             .enumerate()
         {
             if index > 0 {
-                let _ = plain_sha256_hasher.write(b"\n")?;
-                let _ = plain_md5_hasher.write(b"\n")?;
+                plain_sha256_hasher.update(b"\n");
+                plain_md5_hasher.update(b"\n");
                 let _ = gz_encoder.write(b"\n")?;
                 plain_size += 1;
             }
             let display = package.serialize().to_string();
             plain_size += display.len() as u64;
-            let _ = plain_sha256_hasher.write(display.as_bytes())?;
-            let _ = plain_md5_hasher.write(display.as_bytes())?;
+            plain_sha256_hasher.update(display.as_bytes());
+            plain_md5_hasher.update(display.as_bytes());
             let _ = gz_encoder.write(display.as_bytes())?;
             packages.push(package);
         }


### PR DESCRIPTION
Supersedes #107 — dependabot's bump rebased onto main, plus the source changes it needs.

md-5 0.11 moves to digest 0.11, while sha2 stays on digest 0.10 (pinned by rsa 0.9). Two consequences:

- The two `Digest` traits are now distinct types. Scopes that hash with both had been importing one trait and relying on it to cover both hashers; each now needs its own `use ... as _`.
- digest 0.11 drops the `io::Write` impl. `Digest::update` replaces those calls — infallible, and not subject to the partial-write bug `Write::write` could produce.

`gz_encoder.write` is untouched; it is a real `io::Write`.

- `cargo clippy --all-targets --all-features --tests --workspace` clean
- `cargo test --tests --workspace`: 93 passed (includes the checksum assertions in `domain`)