### PR TITLE
ci: run testing on every pull request

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,12 +5,6 @@ on:
     types: [checks_requested]
   workflow_call:
   pull_request:
-    paths:
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "resources/**"
-      - "src/**"
-      - "tests/**"
   push:
     branches:
       - main


### PR DESCRIPTION
`testing` is a required status check on `main`, but `testing.yml`'s `pull_request` trigger is filtered to `Cargo.*`, `resources/**`, `src/**`, `tests/**`. Any PR that touches none of those never runs the workflow, the required context never reports, and the PR is permanently `BLOCKED` — all green checks, still unmergeable.

That is what is currently holding #109, #110 and #111 (GitHub Actions bumps, which only touch `.github/workflows/**`).

Removing the filter matches `code-checking.yml`, the other required check, which already runs on every PR. Cost is the test suite running on docs-only changes; correctness of the required-check gate is worth more.