### PR TITLE
ci: grant checks:write to the security audit job

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -11,6 +11,11 @@ on:
 jobs:
   security_audit:
     runs-on: ubuntu-latest
+    # audit-check publishes its findings as a commit check, which the
+    # read-only default token cannot create.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2.0.0


### PR DESCRIPTION
`security audit` has been failing on `main` since the first Cargo.lock change today. It is **not** a vulnerability — `cargo audit` reports `"vulnerabilities":{"found":false,"count":0}`.

The job dies here:

```
##[error]Resource not accessible by integration - .../checks/runs#create-a-check-run
```

`rustsec/audit-check` only publishes a commit check when it has something to report, and this repo's default workflow token is `read`. So the missing `checks: write` was latent from the day the workflow was written — nothing ever triggered a report.

What changed is upstream, not in this repo: `spin 0.9.8` was yanked from crates.io some time after v0.3.5. It was already in `Cargo.lock` when the audit last passed on 2026-07-09. That yanked warning makes `shouldReport` true, the action tries to create the check, and the permission error surfaces. Today's dependency merges only re-triggered the path-filtered workflow for the first time since the yank.

With the permission granted the job passes: the action sets the check conclusion from `stats.critical`, and a yanked crate counts as `other`, not critical.

`spin 0.9.8` itself is transitive (`flume` → `sqlx-sqlite`, and `lazy_static`) and can't be bumped from here — it needs those crates to move first. It is a yank, not an advisory.