### PR TITLE
docs: forbid AI attribution in commits and pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
 # Agent Instructions
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines, code style, and contribution opportunities.
+
+## Attribution
+
+**Never mention Claude, Claude Code, or any AI assistant in commits or pull requests.**
+
+This is a hard rule and is not open to exception. It covers the commit message
+body, trailers (`Co-Authored-By` and friends), PR titles, and PR descriptions.
+Commits and PRs are authored by the human running the tool.


### PR DESCRIPTION
Records a hard project rule: commits and pull requests must never mention an AI assistant — no `Co-Authored-By` trailers, no generation footers, nothing in titles or descriptions. Commits are authored by the person running the tool.

Added to `AGENTS.md`. `CLAUDE.md` carries the same rule but is covered by a global gitignore, so it stays a local file.