### PR TITLE
ci: allow the security audit to be run on demand

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,6 +1,7 @@
 name: security audit
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
The security audit only triggers on pushes to `main` that touch `Cargo.toml` or `Cargo.lock`. That makes changes to the workflow itself unverifiable — #123 fixed the job's permissions but could not re-run to prove it, since it only touched the workflow file.

`workflow_dispatch` also makes it possible to re-run an audit when a new advisory lands without waiting for a dependency change.